### PR TITLE
Use google.golang.org/protobuf for the protobuf library

### DIFF
--- a/compiler/extensions.go
+++ b/compiler/extensions.go
@@ -20,8 +20,8 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes/any"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 	yaml "gopkg.in/yaml.v3"
 
 	extensions "github.com/google/gnostic-models/extensions"
@@ -33,7 +33,7 @@ type ExtensionHandler struct {
 }
 
 // CallExtension calls a binary extension handler.
-func CallExtension(context *Context, in *yaml.Node, extensionName string) (handled bool, response *any.Any, err error) {
+func CallExtension(context *Context, in *yaml.Node, extensionName string) (handled bool, response *anypb.Any, err error) {
 	if context == nil || context.ExtensionHandlers == nil {
 		return false, nil, nil
 	}
@@ -50,7 +50,7 @@ func CallExtension(context *Context, in *yaml.Node, extensionName string) (handl
 	return handled, response, err
 }
 
-func (extensionHandlers *ExtensionHandler) handle(in *yaml.Node, extensionName string) (*any.Any, error) {
+func (extensionHandlers *ExtensionHandler) handle(in *yaml.Node, extensionName string) (*anypb.Any, error) {
 	if extensionHandlers.Name != "" {
 		yamlData, _ := yaml.Marshal(in)
 		request := &extensions.ExtensionHandlerRequest{

--- a/extensions/extensions.go
+++ b/extensions/extensions.go
@@ -19,8 +19,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 type extensionHandler func(name string, yamlInput string) (bool, proto.Message, error)
@@ -54,7 +54,7 @@ func Main(handler extensionHandler) {
 		response.Errors = append(response.Errors, err.Error())
 	} else if handled {
 		response.Handled = true
-		response.Value, err = ptypes.MarshalAny(output)
+		response.Value, err = anypb.New(output)
 		if err != nil {
 			response.Errors = append(response.Errors, err.Error())
 		}

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,5 @@ go 1.18
 
 require (
 	google.golang.org/protobuf v1.27.1
-	gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )
-
-require github.com/golang/protobuf v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,9 @@
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
-github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
-github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
Use google.golang.org/protobuf for the protobuf library instead of the deprecated github.com/golang/protobuf

Not sure if I broke anything during this migration, @timburks do you know how this is usually tested?

/assign @timburks 

