### PR TITLE
Disable protoc download in CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,12 +21,12 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
       
-    # not sure if this part is necessary for the current repo
-    - name: Get protoc
-      run: |
-        sudo curl -L https://github.com/protocolbuffers/protobuf/releases/download/v3.15.0/protoc-3.15.0-linux-x86_64.zip > /tmp/protoc.zip
-        sudo unzip /tmp/protoc.zip -d /usr/local
-        sudo chown -R $USER /usr/local
+    # Disable protoc download until we have proper validation in place
+    # - name: Get protoc
+    #   run: |
+    #     sudo curl -L https://github.com/protocolbuffers/protobuf/releases/download/v3.15.0/protoc-3.15.0-linux-x86_64.zip > /tmp/protoc.zip
+    #     sudo unzip /tmp/protoc.zip -d /usr/local
+    #     sudo chown -R $USER /usr/local
         
     - name: Get dependencies
       run: go get -v -t -d ./...


### PR DESCRIPTION
Disable protoc download in CI.

We're currently not using it and it's causing a lot of CI time