### PR TITLE
Use absolute import paths in option go_package

### DIFF
--- a/discovery/discovery.proto
+++ b/discovery/discovery.proto
@@ -42,7 +42,7 @@ option java_package = "org.discovery_v1";
 option objc_class_prefix = "OAS";
 
 // The Go package name.
-option go_package = "./discovery;discovery_v1";
+option go_package = "github.com/google/gnostic-models/discovery;discovery_v1";
 
 message Annotations {
   repeated string required = 1;

--- a/extensions/extension.proto
+++ b/extensions/extension.proto
@@ -42,7 +42,7 @@ option java_package = "org.gnostic.v1";
 option objc_class_prefix = "GNX";
 
 // The Go package name.
-option go_package = "./extensions;gnostic_extension_v1";
+option go_package = "github.com/google/gnostic-models/extensions;gnostic_extension_v1";
 
 // The version number of Gnostic.
 message Version {

--- a/openapiv2/OpenAPIv2.proto
+++ b/openapiv2/OpenAPIv2.proto
@@ -42,7 +42,7 @@ option java_package = "org.openapi_v2";
 option objc_class_prefix = "OAS";
 
 // The Go package name.
-option go_package = "./openapiv2;openapi_v2";
+option go_package = "github.com/google/gnostic-models/openapiv2;openapi_v2";
 
 message AdditionalPropertiesItem {
   oneof oneof {

--- a/openapiv3/OpenAPIv3.proto
+++ b/openapiv3/OpenAPIv3.proto
@@ -42,7 +42,7 @@ option java_package = "org.openapi_v3";
 option objc_class_prefix = "OAS";
 
 // The Go package name.
-option go_package = "./openapiv3;openapi_v3";
+option go_package = "github.com/google/gnostic-models/openapiv3;openapi_v3";
 
 message AdditionalPropertiesItem {
   oneof oneof {

--- a/openapiv3/annotations.proto
+++ b/openapiv3/annotations.proto
@@ -20,7 +20,7 @@ import "google/protobuf/descriptor.proto";
 import "openapiv3/OpenAPIv3.proto";
 
 // The Go package name.
-option go_package = "./openapiv3;openapi_v3";
+option go_package = "github.com/google/gnostic-models/openapiv3;openapi_v3";
 // This option lets the proto compiler generate Java code inside the package
 // name (see below) instead of inside an outer class. It creates a simpler
 // developer experience by reducing one-level of name nesting and be


### PR DESCRIPTION
This changes `option go_package` to use absolute import paths instead of relative ones. This fixes two build issues when using this library with Bazel via bazel_gazelle.

Example build errors fixed by this change:

```
ERROR: /home/sloretz/projects/bg_bug/streaming_service/BUILD:13:17: GoCompilePkg streaming_service/streaming_service_go_proto.a failed: (Exit 1): builder failed: error executing GoCompilePkg command (from target //streaming_service:streaming_service_go_proto) bazel-out/k8-opt-exec-ST-d57f47055a04/bin/external/rules_go++go_sdk+main___download_0/builder_reset/builder compilepkg -sdk external/rules_go++go_sdk+main___download_0 -goroot ... (remaining 67 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
bazel-out/k8-fastbuild/bin/streaming_service/streaming_service_go_proto_/bg_bug/streaming_service/streaming_service_go_proto/streaming_service.pb.go:10:4: could not import ./openapiv3 (open : no such file or directory)
compilepkg: error running subcommand external/rules_go++go_sdk+main___download_0/pkg/tool/linux_amd64/compile: exit status 2
```

```
ERROR: /home/sloretz/.cache/bazel/_bazel_sloretz/7f1c610792df1dcd4df92ba962d4dced/external/gazelle++go_deps+com_github_google_gnostic_models/extensions/BUILD.bazel:19:11: GoCompilePkg external/gazelle++go_deps+com_github_google_gnostic_models/extensions/extensions.a [for tool] failed: (Exit 1): builder failed: error executing GoCompilePkg command (from target @@gazelle++go_deps+com_github_google_gnostic_models//extensions:extensions) bazel-out/k8-opt-exec-ST-1be4dcb80a27/bin/external/rules_go++go_sdk+main___download_0/builder_reset/builder compilepkg -sdk external/rules_go++go_sdk+main___download_0 -goroot ... (remaining 29 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
external/gazelle++go_deps+com_github_google_gnostic_models/extensions/extensions.go:40:14: undefined: ExtensionHandlerRequest
external/gazelle++go_deps+com_github_google_gnostic_models/extensions/extensions.go:49:15: undefined: ExtensionHandlerResponse
compilepkg: error running subcommand external/rules_go++go_sdk+main___download_0/pkg/tool/linux_amd64/compile: exit status 2
Use --verbose_failures to see the command lines of failed build steps.
```

I don't know enough about golang to be able to explain why this fixes the issue 🤷 