### PR TITLE
compiler: validate $ref URLs in fetchFile to prevent SSRF

### DIFF
--- a/compiler/reader.go
+++ b/compiler/reader.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -145,6 +146,58 @@ func FetchFile(fileurl string) ([]byte, error) {
 	return fetchFile(fileurl)
 }
 
+// privateIPRanges lists IP ranges that must not be fetched by gnostic to
+// prevent Server-Side Request Forgery (SSRF) against cloud metadata services,
+// internal networks, and loopback addresses.
+var privateIPRanges = func() []net.IPNet {
+	cidrs := []string{
+		"10.0.0.0/8",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+		"127.0.0.0/8",
+		"169.254.0.0/16", // link-local, includes cloud instance metadata (169.254.169.254)
+		"100.64.0.0/10",  // shared address space (RFC 6598)
+		"0.0.0.0/8",
+		"::1/128",        // IPv6 loopback
+		"fc00::/7",       // IPv6 unique local
+		"fe80::/10",      // IPv6 link-local
+	}
+	nets := make([]net.IPNet, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		_, n, err := net.ParseCIDR(cidr)
+		if err != nil {
+			panic(fmt.Sprintf("invalid CIDR %q: %v", cidr, err))
+		}
+		nets = append(nets, *n)
+	}
+	return nets
+}()
+
+// validateFetchURL returns an error if rawURL is not safe to fetch.
+// It enforces an http/https scheme allowlist and blocks requests to
+// private, loopback, and link-local IP addresses to prevent SSRF.
+func validateFetchURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL %q: %v", rawURL, err)
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+		// allowed
+	default:
+		return fmt.Errorf("URL scheme %q is not allowed in $ref; only http and https are permitted", u.Scheme)
+	}
+	host := u.Hostname()
+	if ip := net.ParseIP(host); ip != nil {
+		for _, r := range privateIPRanges {
+			if r.Contains(ip) {
+				return fmt.Errorf("URL %q targets a private or reserved IP address and cannot be fetched", rawURL)
+			}
+		}
+	}
+	return nil
+}
+
 func fetchFile(fileurl string) ([]byte, error) {
 	var bytes []byte
 	initializeFileCache()
@@ -159,6 +212,9 @@ func fetchFile(fileurl string) ([]byte, error) {
 		if verboseReader {
 			log.Printf("Fetching %s", fileurl)
 		}
+	}
+	if err := validateFetchURL(fileurl); err != nil {
+		return nil, err
 	}
 	response, err := http.Get(fileurl)
 	if err != nil {


### PR DESCRIPTION
## Summary

`fetchFile()` in `compiler/reader.go` called `http.Get()` with any URL derived from a `$ref` value in a user-supplied OpenAPI specification, with no validation of the URL scheme or destination host. An attacker who can supply a crafted spec to a gnostic-based CI pipeline or tool can cause gnostic to make HTTP requests to:

- Cloud instance metadata endpoints (e.g. `http://169.254.169.254/latest/meta-data/iam/security-credentials/`)
- Internal network services (RFC 1918 ranges)
- Loopback addresses
- Non-HTTP URI schemes

## Root Cause

`readBytesForFile()` detects whether a `$ref` value is a URL by checking `url.Parse().Scheme != ""` and, if true, passes the raw string directly to `fetchFile()`. `fetchFile()` then calls `http.Get(fileurl)` with no further validation.

## Fix

This commit adds `validateFetchURL()` which is called inside `fetchFile()` before the HTTP request is issued. It enforces:

1. **Scheme allowlist** — only `http` and `https` are permitted; any other scheme (e.g. `file://`, `ftp://`) is rejected with an error.
2. **Private/reserved IP blocklist** — if the URL host is a literal IP address, it is checked against:
   - `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` (RFC 1918)
   - `127.0.0.0/8` (loopback)
   - `169.254.0.0/16` (link-local / cloud IMDS)
   - `100.64.0.0/10` (shared address space, RFC 6598)
   - IPv6 equivalents (`::1/128`, `fc00::/7`, `fe80::/10`)

## Example — before patch

```yaml
# malicious_spec.yaml
paths:
  /foo:
    $ref: "http://169.254.169.254/latest/meta-data/iam/security-credentials/"
```

```
$ gnostic --pb-out=. malicious_spec.yaml
# Issues HTTP GET to cloud metadata — IAM credentials returned and cached
```

## Example — after patch

```
$ gnostic --pb-out=. malicious_spec.yaml
Error: URL "http://169.254.169.254/latest/meta-data/iam/security-credentials/" targets a
private or reserved IP address and cannot be fetched
```

## Notes

- Hostname-based private network access (where a public DNS name resolves to a private IP) is not addressed by this patch; that requires post-resolution checking and is a follow-up hardening step.
- The fix does not affect local file resolution (`readBytesForFile` handles the non-URL path separately and is unaffected).

Fixes SSRF vulnerability reported via Google VRP (Issue 495622065).